### PR TITLE
Remove the crt.sh backlog warning

### DIFF
--- a/src/views/CertSearch.vue
+++ b/src/views/CertSearch.vue
@@ -1,13 +1,5 @@
 <template>
   <div class="cert-search">
-    <p class="warning">
-      Warning: crt.sh, the backing data source for this tool, is currently suffering from
-      backlog problems, rendering the reporting here largely inaccurate.
-      This problem is being addressed, but is yet unresolved. Keep an eye
-      <a href="https://groups.google.com/forum/#!forum/crtsh" target="_blank" rel="noopener noreferrer">
-      on the crt.sh mailing list for updates</a>.
-    </p>
-
     <h2>cert-search</h2>
 
     <form class="search-form" @submit="navigateSearch()" @submit.prevent=";">
@@ -613,8 +605,5 @@ c where x509_subjectKeyIdentifier(c.CERTIFICATE) = decode('deadf00d','hex')`
   text-decoration: underline;
   cursor: pointer;
   color: mix(whitesmoke, #2c3c69, 25%);
-}
-.warning {
-  font-size: 0.9rem;
 }
 </style>


### PR DESCRIPTION
Google's argon2018, pilot and rocketeer logs are still badly backlogged, but there shouldn't be an issue anymore.

Precertificates get logged to multiple logs, at least 1 of which isn't backlogged.

New (pre)certificates go to the 2019 log shards, so argon2018's backlog will be less and less relevant going forward.

https://crt.sh/monitored-logs